### PR TITLE
Update podinfo helm repository to GHCR and bump version

### DIFF
--- a/base/podinfo/release.yaml
+++ b/base/podinfo/release.yaml
@@ -13,7 +13,7 @@ spec:
         kind: HelmRepository
         name: podinfo
         namespace: podinfo
-      version: 5.0.0
+      version: 6.5.3
   values:
     # Service should be disabled when using Flagger
     service:

--- a/base/podinfo/source.yaml
+++ b/base/podinfo/source.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: podinfo
 spec:
   interval: 1m
-  url: https://stefanprodan.github.io/podinfo
+  type: oci
+  url: oci://ghcr.io/stefanprodan/charts/podinfo

--- a/production/podinfo-values.yaml
+++ b/production/podinfo-values.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "6.0.0"
+      version: "6.5.3"
   test:
     enable: false
   values:

--- a/test/podinfo-values.yaml
+++ b/test/podinfo-values.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      version: "6.0.0"
+      version: "6.5.3"
   test:
     enable: false
   values:


### PR DESCRIPTION
*Issue #, if available:* #1

*Description of changes:* Updates Podinfo helm repository. The main repository is GitHub Container Registry as per [docs](https://artifacthub.io/packages/helm/podinfo/podinfo). Also bumps podinfo version to `6.5.3` as deployment of previous versions was failing on K8s `1.27`.

This PR is meant to be merged together with https://github.com/aws-samples/flux-eks-gitops-config/pull/14


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
